### PR TITLE
Pagination: Set default page size to 10 to avoid inconsistent defaults

### DIFF
--- a/src/Http/Request/Request.php
+++ b/src/Http/Request/Request.php
@@ -94,7 +94,7 @@ class Request extends \Zend\Diactoros\Request
             (!empty($queryParam['cursor'])) ? $queryParam['cursor'] : null,
             (!empty($queryParam['limit'])) ? $queryParam['limit'] : null,
             (!empty($queryParam['offset'])) ? $queryParam['offset'] : null,
-            (!empty($queryParam['size'])) ? $queryParam['size'] : null
+            (!empty($queryParam['size'])) ? $queryParam['size'] : 10
         );
 
         return $page;


### PR DESCRIPTION
Since the default value for items per page is 10, this value has to be returned when creating a new Page object, instead of null.

This addresses the bug that the (Laravel 5 based) API will return 15 items in the 'data' array (instead of the desired 10), but supply 10 as the meta-size. When supplying the 10 via GET, e.g. "/employees?page[size]=10", everything is correct. Otherwise, the above described will create a response like that:

```
GET /employees
```

``` json
{
"data": [{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}], // 15 objects
"included": [],
"links": {
"self": {"href": "/employees?page[number]=1&page[size]=10"},
"first": {"href": "/employees?page[number]=1&page[size]=10"},
"next": {"href": "/employees?page[number]=2&page[size]=10"},
"last": {"href": "/employees?page[number]=2&page[size]=10"}
},
"meta": {
"page": {
"total": 17,
"last": 2,
"number": 1,
"size": 10
}
},
"jsonapi": {"version": "1.0"}
}
```
