### PR TITLE
The pagination links in the returned JSON API response include the pr…

### DIFF
--- a/src/Server/Actions/ListResource.php
+++ b/src/Server/Actions/ListResource.php
@@ -176,7 +176,7 @@ class ListResource
                 'self' => $pageNumber,
                 'first' => 1,
                 'next' => ($next <= $last) ? $next : null,
-                'previous' => ($previous > 1) ? $previous : null,
+                'previous' => ($previous >= 1) ? $previous : null,
                 'last' => $last,
             ]
         );


### PR DESCRIPTION
…evious link on all pages except for pages 1 and 2. This is understandable and correct for page 1, however page 2 should have a previous page included.
