### PR TITLE
Reversed hidden attribute commits, but kept empty "include=" fix

### DIFF
--- a/src/Http/Request/Parameters/Included.php
+++ b/src/Http/Request/Parameters/Included.php
@@ -20,11 +20,6 @@ class Included
     protected $included = [];
 
     /**
-     * @var bool
-     */
-    protected $hidden = false;
-
-    /**
      * @param string $relationship
      */
     public function add($relationship)
@@ -57,21 +52,5 @@ class Included
     public function isEmpty()
     {
         return 0 === count($this->included);
-    }
-
-    /**
-     * @param bool $hidden
-     */
-    public function setHidden($hidden = true)
-    {
-        $this->hidden = $hidden;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isHidden()
-    {
-        return $this->hidden;
     }
 }

--- a/src/Http/Request/Request.php
+++ b/src/Http/Request/Request.php
@@ -55,8 +55,9 @@ class Request extends \Zend\Diactoros\Request
 
         if (is_string($include) && strlen($include)) {
             $includeNames = \explode(',', $include);
-            foreach ($includeNames as $relationship) {
+            foreach($includeNames as $relationship) {
                 $included->add($relationship);
+            }
         }
 
         return $included;

--- a/src/Http/Request/Request.php
+++ b/src/Http/Request/Request.php
@@ -53,15 +53,10 @@ class Request extends \Zend\Diactoros\Request
         $include = $this->getQueryParam('include', []);
         $included = new Included();
 
-        if (is_string($include)) {
-            if (!strlen($include)) {
-                $included->setHidden();
-            } else {
-                $includeNames = \explode(',', $include);
-                foreach ($includeNames as $relationship) {
-                    $included->add($relationship);
-                }
-            }
+        if (is_string($include) && strlen($include)) {
+            $includeNames = \explode(',', $include);
+            foreach ($includeNames as $relationship) {
+                $included->add($relationship);
         }
 
         return $included;

--- a/src/Http/Request/Request.php
+++ b/src/Http/Request/Request.php
@@ -55,7 +55,7 @@ class Request extends \Zend\Diactoros\Request
 
         if (is_string($include) && strlen($include)) {
             $includeNames = \explode(',', $include);
-            foreach($includeNames as $relationship) {
+            foreach ($includeNames as $relationship) {
                 $included->add($relationship);
             }
         }

--- a/src/JsonApiSerializer.php
+++ b/src/JsonApiSerializer.php
@@ -64,11 +64,7 @@ class JsonApiSerializer extends DeepCopySerializer
      */
     protected function filterOutIncludedResources(Included $included)
     {
-        if ($included->isHidden()) {
-            foreach ($this->serializationStrategy->getMappings() as $mapping) {
-                $mapping->filteringIncludedResources(true);
-            }
-        } elseif (false === $included->isEmpty()) {
+        if (false === $included->isEmpty()) {
             foreach ($included->get() as $resource => $includeData) {
                 foreach ($this->serializationStrategy->getMappings() as $mapping) {
                     $mapping->filteringIncludedResources(true);

--- a/tests/Http/Request/Parameters/IncludedTest.php
+++ b/tests/Http/Request/Parameters/IncludedTest.php
@@ -36,9 +36,4 @@ class IncludedTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->included->isEmpty());
     }
-
-    public function testIsHidden()
-    {
-        $this->assertFalse($this->included->isHidden());
-    }
 }


### PR DESCRIPTION
The hidden attribute is only needed when the default value for filter was false, which is fixed here: https://github.com/nilportugues/php-api-transformer/pull/7

There is a fix for the exception thrown when a client uses "include=" without any parameters though
