### PR TITLE
DateTime object tests

### DIFF
--- a/tests/Dummy/ComplexObject/Comment.php
+++ b/tests/Dummy/ComplexObject/Comment.php
@@ -30,17 +30,23 @@ class Comment
     private $comment;
 
     /**
+     * @var \DateTime
+     */
+    private $oneDate;
+
+    /**
      * @param CommentId $id
      * @param           $comment
      * @param User      $user
      * @param array     $dates
      */
-    public function __construct(CommentId $id, $comment, User $user, array $dates)
+    public function __construct(CommentId $id, $comment, User $user, array $dates, \DateTime $d = null)
     {
         $this->commentId = $id;
         $this->comment = $comment;
         $this->user = $user;
         $this->dates = $dates;
+        $this->oneDate = $d;
     }
 
     /**

--- a/tests/HelperFactory.php
+++ b/tests/HelperFactory.php
@@ -45,7 +45,7 @@ class HelperFactory
                     [
                         'created_at' => (new DateTime('2015-07-18T12:13:00+00:00'))->format('c'),
                         'accepted_at' => (new DateTime('2015-07-19T00:00:00+00:00'))->format('c'),
-                    ]
+                    ], new DateTime('2015-07-18T12:13:00+00:00')
                 ),
             ]
         );

--- a/tests/JsonApiTransformerTest.php
+++ b/tests/JsonApiTransformerTest.php
@@ -139,7 +139,8 @@ class JsonApiTransformerTest extends \PHPUnit_Framework_TestCase
                "created_at":"2015-07-18T12:13:00+00:00",
                "accepted_at":"2015-07-19T00:00:00+00:00"
             },
-            "comment":"Have no fear, sers, your king is safe."
+            "comment":"Have no fear, sers, your king is safe.",
+        	"oneDate":"2015-07-18T12:13:00+00:00"
          },
          "relationships":{
             "user":{


### PR DESCRIPTION
Here is what I mentioned on [this issue](https://github.com/nilportugues/symfony-jsonapi/issues/21#issuecomment-229204260) from symfony-jsonapi.
I'm using DateTime objects like this because Doctrine results include date fields in this way.
