### PR TITLE
Add ForbiddenException and forbidden response method

### DIFF
--- a/src/Server/Actions/CreateResource.php
+++ b/src/Server/Actions/CreateResource.php
@@ -17,6 +17,7 @@ use NilPortugues\Api\JsonApi\Server\Data\DataException;
 use NilPortugues\Api\JsonApi\Server\Data\DataObject;
 use NilPortugues\Api\JsonApi\Server\Errors\Error;
 use NilPortugues\Api\JsonApi\Server\Errors\ErrorBag;
+use NilPortugues\Api\JsonApi\Server\Actions\Exceptions\ForbiddenException;
 
 /**
  * Class CreateResource.
@@ -76,6 +77,9 @@ class CreateResource
     protected function getErrorResponse(Exception $e, ErrorBag $errorBag)
     {
         switch (get_class($e)) {
+            case ForbiddenException::class:
+                $response = $this->forbidden($errorBag);
+                break;
             case DataException::class:
                 $response = $this->unprocessableEntity($errorBag);
                 break;

--- a/src/Server/Actions/DeleteResource.php
+++ b/src/Server/Actions/DeleteResource.php
@@ -16,6 +16,7 @@ use NilPortugues\Api\JsonApi\Server\Actions\Traits\ResponseTrait;
 use NilPortugues\Api\JsonApi\Server\Errors\Error;
 use NilPortugues\Api\JsonApi\Server\Errors\ErrorBag;
 use NilPortugues\Api\JsonApi\Server\Errors\NotFoundError;
+use NilPortugues\Api\JsonApi\Server\Actions\Exceptions\ForbiddenException;
 
 /**
  * Class DeleteResource.
@@ -65,7 +66,30 @@ class DeleteResource
 
             return $this->resourceDeleted();
         } catch (Exception $e) {
-            return $this->errorResponse(new ErrorBag([new Error('Bad Request', 'Request could not be served.')]));
+            return $this->getErrorResponse($e, $this->errorBag);
         }
+    }
+
+    /**
+     * @param Exception $e
+     * @param ErrorBag  $errorBag
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function getErrorResponse(Exception $e, ErrorBag $errorBag)
+    {
+        switch (get_class($e)) {
+            case ForbiddenException::class:
+                $response = $this->forbidden(
+                    new ErrorBag([new Error($e->getTitle(), $e->getMessage())])
+                );
+                break;
+            default:
+                $response = $this->errorResponse(
+                    new ErrorBag([new Error('Bad Request', 'Request could not be served.')])
+                );
+        }
+
+        return $response;
     }
 }

--- a/src/Server/Actions/Exceptions/ForbiddenException.php
+++ b/src/Server/Actions/Exceptions/ForbiddenException.php
@@ -12,7 +12,7 @@ class ForbiddenException extends \Exception
      * @param string $message
      * @param Exception $previous
      */
-    public function __construct($message, $previous=null)
+    public function __construct($message, $previous = null)
     {
         parent::__construct($message, 403, $previous);
     }
@@ -20,11 +20,13 @@ class ForbiddenException extends \Exception
     /**
      * @param string $title
      */
-    public function setTitle($title) {
+    public function setTitle($title)
+    {
         $this->title = $title;
     }
 
-    public function getTitle() {
+    public function getTitle()
+    {
         return $this->title;
     }
 }

--- a/src/Server/Actions/Exceptions/ForbiddenException.php
+++ b/src/Server/Actions/Exceptions/ForbiddenException.php
@@ -1,0 +1,30 @@
+<?php
+namespace NilPortugues\Api\JsonApi\Server\Actions\Exceptions;
+
+/**
+ * Class ForbiddenException.
+ */
+class ForbiddenException extends \Exception
+{
+    private $title = "Forbidden";
+
+    /**
+     * @param string $message
+     * @param Exception $previous
+     */
+    public function __construct($message, $previous=null)
+    {
+        parent::__construct($message, 403, $previous);
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title) {
+        $this->title = $title;
+    }
+
+    public function getTitle() {
+        return $this->title;
+    }
+}

--- a/src/Server/Actions/GetResource.php
+++ b/src/Server/Actions/GetResource.php
@@ -22,6 +22,7 @@ use NilPortugues\Api\JsonApi\Server\Errors\ErrorBag;
 use NilPortugues\Api\JsonApi\Server\Errors\NotFoundError;
 use NilPortugues\Api\JsonApi\Server\Query\QueryException;
 use NilPortugues\Api\JsonApi\Server\Query\QueryObject;
+use NilPortugues\Api\JsonApi\Server\Actions\Exceptions\ForbiddenException;
 
 /**
  * Class GetResource.
@@ -102,6 +103,9 @@ class GetResource
     protected function getErrorResponse(Exception $e)
     {
         switch (get_class($e)) {
+            case ForbiddenException::class:
+                $response = $this->forbidden($errorBag);
+                break;
             case QueryException::class:
                 $response = $this->errorResponse($this->errorBag);
                 break;

--- a/src/Server/Actions/ListResource.php
+++ b/src/Server/Actions/ListResource.php
@@ -24,6 +24,7 @@ use NilPortugues\Api\JsonApi\Server\Errors\ErrorBag;
 use NilPortugues\Api\JsonApi\Server\Errors\OufOfBoundsError;
 use NilPortugues\Api\JsonApi\Server\Query\QueryException;
 use NilPortugues\Api\JsonApi\Server\Query\QueryObject;
+use NilPortugues\Api\JsonApi\Server\Actions\Exceptions\ForbiddenException;
 
 /**
  * Class ListResource.
@@ -256,6 +257,9 @@ class ListResource
     protected function getErrorResponse(Exception $e)
     {
         switch (get_class($e)) {
+            case ForbiddenException::class:
+                $response = $this->forbidden($errorBag);
+                break;
             case QueryException::class:
                 $response = $this->errorResponse($this->errorBag);
                 break;
@@ -264,8 +268,6 @@ class ListResource
                 $response = $this->errorResponse(
                     new ErrorBag([new Error('Bad Request', 'Request could not be served.')])
                 );
-
-                return $response;
         }
 
         return $response;

--- a/src/Server/Actions/PatchResource.php
+++ b/src/Server/Actions/PatchResource.php
@@ -18,6 +18,7 @@ use NilPortugues\Api\JsonApi\Server\Data\DataObject;
 use NilPortugues\Api\JsonApi\Server\Errors\Error;
 use NilPortugues\Api\JsonApi\Server\Errors\ErrorBag;
 use NilPortugues\Api\JsonApi\Server\Errors\NotFoundError;
+use NilPortugues\Api\JsonApi\Server\Actions\Exceptions\ForbiddenException;
 
 /**
  * Class PatchResource.
@@ -85,6 +86,9 @@ class PatchResource
     protected function getErrorResponse(Exception $e)
     {
         switch (get_class($e)) {
+            case ForbiddenException::class:
+                $response = $this->forbidden($errorBag);
+                break;
             case DataException::class:
                 $response = $this->unprocessableEntity($this->errorBag);
                 break;

--- a/src/Server/Actions/PutResource.php
+++ b/src/Server/Actions/PutResource.php
@@ -18,6 +18,7 @@ use NilPortugues\Api\JsonApi\Server\Data\DataObject;
 use NilPortugues\Api\JsonApi\Server\Errors\Error;
 use NilPortugues\Api\JsonApi\Server\Errors\ErrorBag;
 use NilPortugues\Api\JsonApi\Server\Errors\NotFoundError;
+use NilPortugues\Api\JsonApi\Server\Actions\Exceptions\ForbiddenException;
 
 /**
  * Class PutResource.
@@ -85,6 +86,9 @@ class PutResource
     protected function getErrorResponse(Exception $e)
     {
         switch (get_class($e)) {
+            case ForbiddenException::class:
+                $response = $this->forbidden($errorBag);
+                break;
             case DataException::class:
                 $response = $this->unprocessableEntity($this->errorBag);
                 break;

--- a/src/Server/Actions/Traits/ResponseTrait.php
+++ b/src/Server/Actions/Traits/ResponseTrait.php
@@ -21,6 +21,7 @@ use NilPortugues\Api\JsonApi\Http\Response\ResourceUpdated;
 use NilPortugues\Api\JsonApi\Http\Response\Response;
 use NilPortugues\Api\JsonApi\Http\Response\UnprocessableEntity;
 use NilPortugues\Api\JsonApi\Http\Response\UnsupportedAction;
+use NilPortugues\Api\JsonApi\Http\Response\Forbidden;
 use NilPortugues\Api\JsonApi\Server\Errors\ErrorBag;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
@@ -137,5 +138,15 @@ trait ResponseTrait
     protected function unprocessableEntity(ErrorBag $errorBag)
     {
         return (new HttpFoundationFactory())->createResponse($this->addHeaders(new UnprocessableEntity($errorBag)));
+    }
+
+    /**
+     * @param ErrorBag $errorBag
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function forbidden(ErrorBag $errorBag)
+    {
+        return (new HttpFoundationFactory())->createResponse($this->addHeaders(new Forbidden($errorBag)));
     }
 }


### PR DESCRIPTION
I'm using this library and implemented attribute based access controll with laravels gate and policy framework. Therefore I need to check authorisation inside the action callback methods sometimes. To get a more detailed response than just http status 400 on authorisation failure I implemented a ForbiddenException that triggers a 403 forbidden response.

Usage of this exception is totaly optional but I think providing it would be quite nice for people who need to implement authorisation in their own action callback methods. If there is a better way how this can be done I would be happy to receive some feedback.
