### PR TITLE
Support to-many relations in included resources.

### DIFF
--- a/src/Helpers/DataIncludedHelper.php
+++ b/src/Helpers/DataIncludedHelper.php
@@ -172,6 +172,11 @@ class DataIncludedHelper
                 }
             }
         }
+        if (!empty($data[JsonApiTransformer::INCLUDED_KEY])) {
+            $data[JsonApiTransformer::INCLUDED_KEY] = \array_values(
+                \array_unique($data[JsonApiTransformer::INCLUDED_KEY], SORT_REGULAR)
+            );
+        }
     }
 
     protected static function findIncludedIndex($includedData, $idNeedle, $typeNeedle)

--- a/src/Helpers/DataIncludedHelper.php
+++ b/src/Helpers/DataIncludedHelper.php
@@ -155,15 +155,27 @@ class DataIncludedHelper
                     $arrayData[JsonApiTransformer::RELATIONSHIPS_KEY] = $relationships;
                 }
 
-                $data[JsonApiTransformer::INCLUDED_KEY][] = \array_filter($arrayData);
+                $existingIndex = false;
+                if (array_key_exists(JsonApiTransformer::INCLUDED_KEY, $data)) {
+                    $existingIndex = self::findIncludedIndex($data[JsonApiTransformer::INCLUDED_KEY], $arrayData[JsonApiTransformer::ID_KEY], $arrayData[JsonApiTransformer::TYPE_KEY]);
+                }
+                if ($existingIndex !== false) {
+                    $data[JsonApiTransformer::INCLUDED_KEY][$existingIndex] = \array_filter(\array_merge($data[JsonApiTransformer::INCLUDED_KEY][$existingIndex], $arrayData));
+                } else {
+                    $data[JsonApiTransformer::INCLUDED_KEY][] = \array_filter($arrayData);
+                }
             }
         }
 
-        if (!empty($data[JsonApiTransformer::INCLUDED_KEY])) {
-            $data[JsonApiTransformer::INCLUDED_KEY] = \array_values(
-                \array_unique($data[JsonApiTransformer::INCLUDED_KEY], SORT_REGULAR)
-            );
-        }
+    }
+
+    protected static function findIncludedIndex($includedData, $idNeedle, $typeNeedle) {
+       foreach ($includedData as $key => $value) {
+           if ($value[JsonApiTransformer::ID_KEY] === $idNeedle && $value[JsonApiTransformer::TYPE_KEY] === $typeNeedle) {
+               return $key;
+           }
+       }
+       return false;
     }
 
     /**

--- a/src/Helpers/DataIncludedHelper.php
+++ b/src/Helpers/DataIncludedHelper.php
@@ -166,9 +166,10 @@ class DataIncludedHelper
                     $existingIndex = self::findIncludedIndex($data[JsonApiTransformer::INCLUDED_KEY], $arrayData[JsonApiTransformer::ID_KEY], $arrayData[JsonApiTransformer::TYPE_KEY]);
                 }
                 if ($existingIndex !== false) {
-                    $data[JsonApiTransformer::INCLUDED_KEY][$existingIndex] = \array_filter(\array_merge($data[JsonApiTransformer::INCLUDED_KEY][$existingIndex], $arrayData));
+                    $data[JsonApiTransformer::INCLUDED_KEY][$existingIndex] = \array_filter(\array_merge($data[JsonApiTransformer::INCLUDED_KEY][$existingIndex],
+                        \array_filter($arrayData, self::filterEmptyArray())), self::filterEmptyArray());
                 } else {
-                    $data[JsonApiTransformer::INCLUDED_KEY][] = \array_filter($arrayData);
+                    $data[JsonApiTransformer::INCLUDED_KEY][] = \array_filter($arrayData, self::filterEmptyArray());
                 }
             }
         }
@@ -177,6 +178,13 @@ class DataIncludedHelper
                 \array_unique($data[JsonApiTransformer::INCLUDED_KEY], SORT_REGULAR)
             );
         }
+    }
+
+    protected static function filterEmptyArray()
+    {
+        return function($value) {
+            return $value !== null && (!is_array($value) || count($value) > 0);
+        };
     }
 
     protected static function findIncludedIndex($includedData, $idNeedle, $typeNeedle)

--- a/src/Helpers/DataIncludedHelper.php
+++ b/src/Helpers/DataIncludedHelper.php
@@ -166,16 +166,17 @@ class DataIncludedHelper
                 }
             }
         }
-
     }
 
-    protected static function findIncludedIndex($includedData, $idNeedle, $typeNeedle) {
-       foreach ($includedData as $key => $value) {
-           if ($value[JsonApiTransformer::ID_KEY] === $idNeedle && $value[JsonApiTransformer::TYPE_KEY] === $typeNeedle) {
-               return $key;
-           }
-       }
-       return false;
+    protected static function findIncludedIndex($includedData, $idNeedle, $typeNeedle)
+    {
+        foreach ($includedData as $key => $value) {
+            if ($value[JsonApiTransformer::ID_KEY] === $idNeedle && $value[JsonApiTransformer::TYPE_KEY] === $typeNeedle) {
+                return $key;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Helpers/DataLinksHelper.php
+++ b/src/Helpers/DataLinksHelper.php
@@ -413,7 +413,7 @@ class DataLinksHelper
      *
      * @return string
      */
-    protected static function camelCaseToUnderscore($camel, $splitter = '_')
+    public static function camelCaseToUnderscore($camel, $splitter = '_')
     {
         $camel = \preg_replace(
             '/(?!^)[[:upper:]][[:lower:]]/',

--- a/tests/Behaviour/Dummy/ComplexObject/Comment.php
+++ b/tests/Behaviour/Dummy/ComplexObject/Comment.php
@@ -35,18 +35,23 @@ class Comment
     private $oneDate;
 
     /**
+     * @var User[]
+     */
+    private $likes;
+    /**
      * @param CommentId $id
      * @param           $comment
      * @param User      $user
      * @param array     $dates
      */
-    public function __construct(CommentId $id, $comment, User $user, array $dates, \DateTime $d = null)
+    public function __construct(CommentId $id, $comment, User $user, array $dates, \DateTime $d = null, $likes = [])
     {
         $this->commentId = $id;
         $this->comment = $comment;
         $this->user = $user;
         $this->dates = $dates;
         $this->oneDate = $d;
+        $this->likes = $likes;
     }
 
     /**

--- a/tests/Behaviour/HelperFactory.php
+++ b/tests/Behaviour/HelperFactory.php
@@ -46,7 +46,17 @@ class HelperFactory
                         'created_at' => (new DateTime('2015-07-18T12:13:00+00:00'))->format('c'),
                         'accepted_at' => (new DateTime('2015-07-19T00:00:00+00:00'))->format('c'),
                     ],
-                    new DateTime('2015-07-18T12:13:00+00:00')
+                    new DateTime('2015-07-18T12:13:00+00:00'),
+                    [
+                        new User(
+                            new UserId(3),
+                            'First Liker'
+                        ),
+                        new User(
+                            new UserId(4),
+                            'Second Liker'
+                        )
+                        ]
                 ),
             ]
         );

--- a/tests/Behaviour/JsonApiTransformerTest.php
+++ b/tests/Behaviour/JsonApiTransformerTest.php
@@ -137,6 +137,42 @@ JSON;
       },
       {
          "type":"user",
+         "id":"3",
+         "attributes":{
+            "name":"First Liker"
+         },
+         "links":{
+            "self":{
+               "href":"http://example.com/users/3"
+            },
+            "friends":{
+               "href":"http://example.com/users/3/friends"
+            },
+            "comments":{
+               "href":"http://example.com/users/3/comments"
+            }
+         }
+      },
+      {
+         "type":"user",
+         "id":"4",
+         "attributes":{
+            "name":"Second Liker"
+         },
+         "links":{
+            "self":{
+               "href":"http://example.com/users/4"
+            },
+            "friends":{
+               "href":"http://example.com/users/4/friends"
+            },
+            "comments":{
+               "href":"http://example.com/users/4/comments"
+            }
+         }
+      },
+      {
+         "type":"user",
          "id":"2",
          "attributes":{
             "name":"Barristan Selmy"
@@ -174,6 +210,18 @@ JSON;
                   "type":"user",
                   "id":"2"
                }
+             },
+            "likes": {
+               "data": [
+                  { 
+                    "type": "user",
+                    "id":"3"
+                  },
+                  {  
+                    "type": "user",
+                    "id":"4"
+                  }
+                ]
             }
          },
          "links":{

--- a/tests/Integrations/Doctrine/DoctrineTest.php
+++ b/tests/Integrations/Doctrine/DoctrineTest.php
@@ -191,7 +191,12 @@ JSON;
 		         "type":"post",
 		         "id":"1",
 		         "attributes":{  
-		            "description":"Description test"
+		            "description":"Description test",
+		            "date":{  
+		               "date":"2016-07-12 16:30:12.000000",
+		               "timezone_type":3,
+		               "timezone":"Europe/Madrid"
+		            }
 		         },
 		         "relationships":{  
 		            "customer":{  
@@ -226,31 +231,6 @@ JSON;
 		         "links":{  
 		            "self":{  
 		               "href":"http://example.com/comment/1"
-		            }
-		         }
-		      },
-		      {  
-		         "type":"post",
-		         "id":"1",
-		         "attributes":{  
-		            "date":{  
-		               "date":"2016-07-12 16:30:12.000000",
-		               "timezone_type":3,
-		               "timezone":"Europe/Madrid"
-		            },
-		            "description":"Description test"
-		         },
-		         "relationships":{  
-		            "customer":{  
-		               "data":{  
-		                  "type":"customer",
-		                  "id":"1"
-		               }
-		            }
-		         },
-		         "links":{  
-		            "self":{  
-		               "href":"http://example.com/post/1"
 		            }
 		         }
 		      }


### PR DESCRIPTION
I noticed an issue while using your awesome library. 

It's currently not possible to include "to-many" relations that are defined in included resources. For example if you have Post and Comment objects like in your unit tests and you want to include an array of "likes" in the Comment object, these aren't included in the result.

Because this is my first pull request, I welcome all kinds of critique. ;)
