### PR TITLE
Unique included data

### DIFF
--- a/src/Helpers/DataIncludedHelper.php
+++ b/src/Helpers/DataIncludedHelper.php
@@ -155,15 +155,27 @@ class DataIncludedHelper
                     $arrayData[JsonApiTransformer::RELATIONSHIPS_KEY] = $relationships;
                 }
 
-                $data[JsonApiTransformer::INCLUDED_KEY][] = \array_filter($arrayData);
+                $existingIndex = false;
+                if (array_key_exists(JsonApiTransformer::INCLUDED_KEY, $data)) {
+                    $existingIndex = self::findIncludedIndex($data[JsonApiTransformer::INCLUDED_KEY], $arrayData[JsonApiTransformer::ID_KEY], $arrayData[JsonApiTransformer::TYPE_KEY]);
+                }
+                if ($existingIndex !== false) {
+                    $data[JsonApiTransformer::INCLUDED_KEY][$existingIndex] = \array_filter(\array_merge($data[JsonApiTransformer::INCLUDED_KEY][$existingIndex], $arrayData));
+                } else {
+                    $data[JsonApiTransformer::INCLUDED_KEY][] = \array_filter($arrayData);
+                }
             }
         }
 
-        if (!empty($data[JsonApiTransformer::INCLUDED_KEY])) {
-            $data[JsonApiTransformer::INCLUDED_KEY] = \array_values(
-                \array_unique($data[JsonApiTransformer::INCLUDED_KEY], SORT_REGULAR)
-            );
-        }
+    }
+
+    protected static function findIncludedIndex($includedData, $idNeedle, $typeNeedle) {
+       foreach ($includedData as $key => $value) {
+           if ($value[JsonApiTransformer::ID_KEY] === $idNeedle && $value[JsonApiTransformer::TYPE_KEY] === $typeNeedle) {
+               return $key;
+           }
+       }
+       return false;
     }
 
     /**

--- a/src/Helpers/DataIncludedHelper.php
+++ b/src/Helpers/DataIncludedHelper.php
@@ -166,16 +166,17 @@ class DataIncludedHelper
                 }
             }
         }
-
     }
 
-    protected static function findIncludedIndex($includedData, $idNeedle, $typeNeedle) {
-       foreach ($includedData as $key => $value) {
-           if ($value[JsonApiTransformer::ID_KEY] === $idNeedle && $value[JsonApiTransformer::TYPE_KEY] === $typeNeedle) {
-               return $key;
-           }
-       }
-       return false;
+    protected static function findIncludedIndex($includedData, $idNeedle, $typeNeedle)
+    {
+        foreach ($includedData as $key => $value) {
+            if ($value[JsonApiTransformer::ID_KEY] === $idNeedle && $value[JsonApiTransformer::TYPE_KEY] === $typeNeedle) {
+                return $key;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Integrations/Doctrine/DoctrineTest.php
+++ b/tests/Integrations/Doctrine/DoctrineTest.php
@@ -191,7 +191,12 @@ JSON;
 		         "type":"post",
 		         "id":"1",
 		         "attributes":{  
-		            "description":"Description test"
+		            "description":"Description test",
+		            "date":{  
+		               "date":"2016-07-12 16:30:12.000000",
+		               "timezone_type":3,
+		               "timezone":"Europe/Madrid"
+		            }
 		         },
 		         "relationships":{  
 		            "customer":{  
@@ -226,31 +231,6 @@ JSON;
 		         "links":{  
 		            "self":{  
 		               "href":"http://example.com/comment/1"
-		            }
-		         }
-		      },
-		      {  
-		         "type":"post",
-		         "id":"1",
-		         "attributes":{  
-		            "date":{  
-		               "date":"2016-07-12 16:30:12.000000",
-		               "timezone_type":3,
-		               "timezone":"Europe/Madrid"
-		            },
-		            "description":"Description test"
-		         },
-		         "relationships":{  
-		            "customer":{  
-		               "data":{  
-		                  "type":"customer",
-		                  "id":"1"
-		               }
-		            }
-		         },
-		         "links":{  
-		            "self":{  
-		               "href":"http://example.com/post/1"
 		            }
 		         }
 		      }


### PR DESCRIPTION
If there are objects in compound documents that have the same key and type, but the objects are not equal, the transformer would put the same resource identifier more than once into the included data. I didn't read about the "uniquness" of compund documents in the JSON API specification, but I suppose that such behaviour is not allowed.

I took the approach to merge objects with the same identifier, because I didn't got any better idea to handle this.
