### PR TITLE
WIP Incorrect included property names

### DIFF
--- a/src/Helpers/DataIncludedHelper.php
+++ b/src/Helpers/DataIncludedHelper.php
@@ -12,6 +12,7 @@
 namespace NilPortugues\Api\JsonApi\Helpers;
 
 use NilPortugues\Api\JsonApi\JsonApiTransformer;
+use NilPortugues\Api\Transformer\Helpers\RecursiveFormatterHelper;
 use NilPortugues\Serializer\Serializer;
 
 class DataIncludedHelper
@@ -93,7 +94,7 @@ class DataIncludedHelper
     ) {
         foreach ($value as $propertyName => $attribute) {
             if (PropertyHelper::isAttributeProperty($mappings, $propertyName, $type)) {
-                $propertyName = DataAttributesHelper::transformToValidMemberName($propertyName);
+                $propertyName = DataAttributesHelper::transformToValidMemberName(RecursiveFormatterHelper::camelCaseToUnderscore($propertyName));
 
                 if (\array_key_exists(Serializer::CLASS_IDENTIFIER_KEY, $attribute)) {
                     self::setResponseDataIncluded($mappings, $value, $data);
@@ -191,7 +192,7 @@ class DataIncludedHelper
     ) {
         foreach ($value as $propertyName => $attribute) {
             if (PropertyHelper::isAttributeProperty($mappings, $propertyName, $type)) {
-                $propertyName = DataAttributesHelper::transformToValidMemberName($propertyName);
+                $propertyName = DataAttributesHelper::transformToValidMemberName(RecursiveFormatterHelper::camelCaseToUnderscore($propertyName));
 
                 if (\is_array($attribute) && \array_key_exists(Serializer::CLASS_IDENTIFIER_KEY, $attribute)) {
                     $data[$propertyName][JsonApiTransformer::DATA_KEY] = PropertyHelper::setResponseDataTypeAndId(

--- a/tests/Behaviour/JsonApiTransformerTest.php
+++ b/tests/Behaviour/JsonApiTransformerTest.php
@@ -162,7 +162,7 @@ JSON;
                "accepted_at":"2015-07-19T00:00:00+00:00"
             },
             "comment":"Have no fear, sers, your king is safe.",
-            "oneDate" : {
+            "one_date" : {
                 "date" : "2015-07-18 12:13:00.000000",
                 "timezone_type": 1,
                 "timezone" : "+00:00"

--- a/tests/Integrations/Doctrine/AbstractTestCase.php
+++ b/tests/Integrations/Doctrine/AbstractTestCase.php
@@ -33,7 +33,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 
         $newCustomer = new Customer();
         $newCustomer->setActive(true);
-        $newCustomer->setName('Name 1');
+        $newCustomer->setPersonName('Name 1');
         self::$entityManager->persist($newCustomer);
 
         $newPost = new Post();

--- a/tests/Integrations/Doctrine/DoctrineTest.php
+++ b/tests/Integrations/Doctrine/DoctrineTest.php
@@ -213,7 +213,7 @@ JSON;
 		         "attributes":{  
 		            "comment":"Comment 1",
 		            "parent_id":null,
-		            "parentComment":null
+		            "parent_comment":null
 		         },
 		         "relationships":{  
 		            "post":{  

--- a/tests/Integrations/Doctrine/DoctrineTest.php
+++ b/tests/Integrations/Doctrine/DoctrineTest.php
@@ -24,7 +24,7 @@ class DoctrineTest extends AbstractTestCase
 		      "attributes":{  
 		         "active":true,
 		         "id":1,
-		         "name":"Name 1"
+		         "person_name":"Name 1"
 		      },
 		      "links":{  
 		         "self":{  
@@ -85,7 +85,7 @@ JSON;
 		         "type":"customer",
 		         "id":"1",
 		         "attributes":{  
-		            "name":"Name 1",
+		            "person_name":"Name 1",
 		            "active":true
 		         },
 		         "links":{  
@@ -178,7 +178,7 @@ JSON;
 		         "type":"customer",
 		         "id":"1",
 		         "attributes":{  
-		            "name":"Name 1",
+		            "person_name":"Name 1",
 		            "active":true
 		         },
 		         "links":{  

--- a/tests/Integrations/Doctrine/Entity/Customer.php
+++ b/tests/Integrations/Doctrine/Entity/Customer.php
@@ -15,7 +15,7 @@ class Customer
     /**
      * @var string
      */
-    private $name;
+    private $personName;
 
     /**
      * @var bool
@@ -35,13 +35,13 @@ class Customer
     /**
      * Set name.
      *
-     * @param string $name
+     * @param string $personName
      *
      * @return Customer
      */
-    public function setName($name)
+    public function setPersonName($personName)
     {
-        $this->name = $name;
+        $this->personName = $personName;
 
         return $this;
     }
@@ -51,9 +51,9 @@ class Customer
      *
      * @return string
      */
-    public function getName()
+    public function getPersonName()
     {
-        return $this->name;
+        return $this->personName;
     }
 
     /**

--- a/tests/Integrations/Doctrine/yml/Customer.orm.yml
+++ b/tests/Integrations/Doctrine/yml/Customer.orm.yml
@@ -9,7 +9,7 @@ NilPortugues\Tests\Api\JsonApi\Integrations\Doctrine\Entity\Customer:
             generator:
                 strategy: AUTO
     fields:
-        name:
+        personName:
             type: string
             length: 255
         active:


### PR DESCRIPTION
This PR shows (but not fixes) a camelCase to underscore_case issue for included objects properties.

Hopefully you are able to direct me to a solution as this is problematic and I can't seem to find the problem.

Edit: this only affects properties of included objects. And I am guessing this https://github.com/nilportugues/php-json-api/issues/87 is related and hopefully fixed when this bug is resolved.