### PR TITLE
Aviod 3.1.0 version conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "nilportugues/api-transformer": "^3.0.0",
+        "nilportugues/api-transformer": "~3.0.0",
         "symfony/psr-http-message-bridge" : "^0.2|^0.3"
     },
     "require-dev": {


### PR DESCRIPTION
https://github.com/nilportugues/php-api-transformer/blob/3.1.0/src/Transformer/Transformer.php#L55 causes `Fatal Compile Error: Declaration of NilPortugues\Api\JsonApi\JsonApiTransformer::serialize($value) must be compatible with NilPortugues\Api\Transformer\Transformer::serialize($value): string`